### PR TITLE
Handle panic when handling non 2.2 SPDX docs

### DIFF
--- a/pkg/spdx/spdx_report.go
+++ b/pkg/spdx/spdx_report.go
@@ -104,7 +104,7 @@ func (r *SpdxReport) CreationInfo() scorecard.ReportValue {
 	foundTool := false
 	hasVersion := false
 
-	if r.doc.CreationInfo == nil {
+	if r.doc == nil || r.doc.CreationInfo == nil {
 		return scorecard.ReportValue{
 			Ratio:     0,
 			Reasoning: "No creation info found",
@@ -191,6 +191,5 @@ func GetSpdxReport(filename string) scorecard.SbomReport {
 			}
 		}
 	}
-
 	return &sr
 }


### PR DESCRIPTION
This PR fixes a bug to avoid a panic when opening SPDX documents which 
are not version  2.2.

/cc @justinabrahms 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>