### PR TITLE
Minor tutorial updates

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -21,7 +21,7 @@ Assuming the user has Go [Go](https://go.dev/doc/install) installed,
 the user can then install the package in `$GOPATH/bin` by running:
 
 ```bash
-go build cmd/sbom-scorecard/main.go
+go install cmd/sbom-scorecard/main.go
 ```
 
 The rest of the tutorial assumes that, if you've gone this route, `$GOPATH/bin` is on your path.
@@ -64,5 +64,5 @@ Note: `sbom-scorecard` will guess the type if no type is specified.
 To run `sbom-scorecard` and specify the output format as JSON, run:
 
 ```bash
-go run cmd/sbom-scorecard/main.go score --outputFormat json examples/dropwizard.cyclonedx.json
+sbom-scorecardscore --outputFormat json examples/dropwizard.cyclonedx.json
 ```

--- a/tutorial.md
+++ b/tutorial.md
@@ -64,5 +64,5 @@ Note: `sbom-scorecard` will guess the type if no type is specified.
 To run `sbom-scorecard` and specify the output format as JSON, run:
 
 ```bash
-sbom-scorecardscore --outputFormat json examples/dropwizard.cyclonedx.json
+sbom-scorecard score --outputFormat json examples/dropwizard.cyclonedx.json
 ```


### PR DESCRIPTION
- Use `go install`, rather than `go build`
- Use the go executable in the final command

Related to @rnjudge's issues with the current tutorial in issue #14 