### PR TITLE
fix nil pointer reference bug & NaN handling on invalid json input

### DIFF
--- a/cmd/sbom-scorecard/cmd/scorecard.go
+++ b/cmd/sbom-scorecard/cmd/scorecard.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"errors"
@@ -34,7 +33,7 @@ func init() {
 }
 
 func determineSbomType(filepath string) string {
-	content, err := ioutil.ReadFile(filepath)
+	content, err := os.ReadFile(filepath)
 	if err != nil {
 		panic(fmt.Sprintf("Error! %v", err))
 	}

--- a/examples/invalid.json
+++ b/examples/invalid.json
@@ -1,0 +1,3 @@
+{
+  "makeJSON": "happy"
+}This is intentionally invalid

--- a/pkg/cdx/cdx_report_test.go
+++ b/pkg/cdx/cdx_report_test.go
@@ -70,5 +70,5 @@ Package ID: 0/20 (0% have purls and 0% have CPEs)
 Package Versions: 0/20
 Package Licenses: 0/20
 Creation Info: 0/15
-Total points: 0/100 or 85%`)
+Total points: 0/100 or 0%`)
 }

--- a/pkg/cdx/cdx_report_test.go
+++ b/pkg/cdx/cdx_report_test.go
@@ -58,3 +58,17 @@ Package Licenses: 18/20
 Creation Info: 15/15
 Total points: 88/100 or 88%`)
 }
+
+func TestCycloneInvalid(t *testing.T) {
+	r := GetCycloneDXReport("../../examples/invalid.json")
+
+	report_text := scorecard.Grade(r)
+	assertTextEqual(t,
+		report_text,
+		`Spec Compliance: 0/25
+Package ID: 0/20 (0% have purls and 0% have CPEs)
+Package Versions: 0/20
+Package Licenses: 0/20
+Creation Info: 0/15
+Total points: 0/100 or 85%`)
+}

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -32,8 +32,14 @@ type ScoreValue struct {
 	MaxPoints float32
 }
 
+func isNaN(f float32) bool { return f != f }
+
 func (sv *ScoreValue) Score() float32 {
-	return sv.Ratio * sv.MaxPoints
+	if isNaN(sv.Ratio) {
+		return 0
+	} else {
+		return sv.Ratio * sv.MaxPoints
+	}
 }
 
 type ReportResult struct {

--- a/pkg/spdx/document.go
+++ b/pkg/spdx/document.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	spdx_json "github.com/spdx/tools-golang/json"
 	spdx_rdf "github.com/spdx/tools-golang/rdfloader"
@@ -37,7 +37,7 @@ type File struct {
 }
 
 func LoadDocument(path string) (Document, error) {
-	f, err := ioutil.ReadFile(path)
+	f, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("opening SPDX document: %w", err)
 	}


### PR DESCRIPTION
It is possible to cause a segfault by providing invalid json.

```
./sbom-scorecard score ../../examples/invalid.json                                                       ⏎ ✹ ✭
Guessed: cdx
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x11acab8]

goroutine 1 [running]:
github.com/ebay/sbom-scorecard/pkg/cdx.GetCycloneDXReport({0x7ff7bfeff647, 0x1b})
	.../sbom-scorecard/pkg/cdx/cdx_report.go:119 +0x2f8
github.com/ebay/sbom-scorecard/cmd/sbom-scorecard/cmd.glob..func1(0x13fef00?, {0xc000063930?, 0x1?, 0x1?})
	.../sbom-scorecard/cmd/sbom-scorecard/cmd/scorecard.go:70 +0x1c8
github.com/spf13/cobra.(*Command).execute(0x13fef00, {0xc0000638f0, 0x1, 0x1})
	.../github.com/spf13/cobra@v1.6.1/command.go:920 +0x847
github.com/spf13/cobra.(*Command).ExecuteC(0x13fec20)
	.../github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	.../github.com/spf13/cobra@v1.6.1/command.go:968
github.com/ebay/sbom-scorecard/cmd/sbom-scorecard/cmd.Execute()
	.../sbom-scorecard/cmd/sbom-scorecard/cmd/root.go:20 +0x25
main.main()
	.../sbom-scorecard/cmd/sbom-scorecard/main.go:8 +0x17
```

[pkg/cdx/cdx_report.go#L127](https://github.com/eBay/sbom-scorecard/pull/32/files#diff-7f1f6257465a73d4dfc8f8d1706241689ccf7824a7852f8db78665ea4d595edbR127)
Fix nil pointer reference in bom.Metadata.Tools which causes nil pointer segfault when an invalid json file is provided.

[pkg/cdx/cdx_report.go#L65](https://github.com/eBay/sbom-scorecard/pull/32/files#diff-d36e979da26bd4d56f074d57a751d953d49033fbc18ddb9f65d3abf25346de17R38)
Fix NaN handling leading to invalid score results when an invalid json file is provided.

The root of this issue is likely that upstream [cyclonedx-go/blob/master/decode.go#L43 ](https://github.com/CycloneDX/cyclonedx-go/blob/master/decode.go#L43) uses `json.Decode` (which accepts a stream) instead of `json.Marshal`.

nit: ioutil package deprecated: As of Go 1.16, this function simply calls os.ReadFile.
