### PR TITLE
fix: Verify metadata is non-nil before accessing for timestamp

### DIFF
--- a/pkg/cdx/cdx_report.go
+++ b/pkg/cdx/cdx_report.go
@@ -190,7 +190,7 @@ func GetCycloneDXReport(filename string) scorecard.SbomReport {
 		}
 	}
 
-	if bom.Metadata.Timestamp != "" {
+	if bom.Metadata != nil && bom.Metadata.Timestamp != "" {
 		r.hasCreationTimestamp = true
 	}
 


### PR DESCRIPTION
This lead to a segfault when metadata was not present in the BOM.

I don't love the code structure, but I preferred making a small change for mergability, one which is also in line with how previous nil-checks are performed.