### PR TITLE
Fix hasPurlOrCPE logic

### DIFF
--- a/pkg/spdx/spdx_report.go
+++ b/pkg/spdx/spdx_report.go
@@ -195,7 +195,7 @@ func GetSpdxReport(filename string) scorecard.SbomReport {
 					foundCPE = true
 				}
 			}
-			if foundCPE && foundPURL {
+			if foundCPE || foundPURL {
 				sr.hasPurlOrCPE += 1
 			}
 


### PR DESCRIPTION
The logic used for `hasPurlOrCPE` in the SPDX reporter is incorrect, it should be a disjunction. It's also inconsistent with the CycloneDX reporter, I believe it was a slip-up in https://github.com/eBay/sbom-scorecard/commit/9d66eae9c06c59afdcaad8c24fadb287cfcaa2ea. This pull request addresses it.